### PR TITLE
UndefVarError: `ImGuiKey_KeyPadEnter` not defined

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ LibCImGui = "9be01004-c4f5-478b-abeb-cb32b114cf5e"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [compat]
-LibCImGui = "1.82.0"
+LibCImGui = "~1.82.0"
 GLFW_jll = "3.3"
 julia = "1.6"
 


### PR DESCRIPTION
After LibCImGui 1.89.4 was released this package is no longer working, see https://github.com/JuliaImGui/ImGuiGLFWBackend.jl/pull/4

So I think we should use more strict semver for LibCImGui dep for current version.