### PR TITLE
Bump version to 0.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImGuiGLFWBackend"
 uuid = "623d79b3-9695-4e60-bd7e-2a5aabaa6933"
 authors = ["Yupei Qi <qiyupei@gmail.com>"]
-version = "0.1.3"
+version = "0.2"
 
 [deps]
 GLFW_jll = "0656b61e-2033-5cc2-a64a-77c0f6c09b89"
@@ -9,7 +9,7 @@ LibCImGui = "9be01004-c4f5-478b-abeb-cb32b114cf5e"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [compat]
-LibCImGui = "~1.82.0"
+LibCImGui = "~1.89.5"
 GLFW_jll = "3.3"
 julia = "1.6"
 


### PR DESCRIPTION
With new compat bounds for the future LibCImGui.jl. Shouldn't be merged before https://github.com/JuliaImGui/LibCImGui.jl/pull/7.